### PR TITLE
Add decimal scaling to stable curve

### DIFF
--- a/programs/hyperplane/fuzz/src/instructions.rs
+++ b/programs/hyperplane/fuzz/src/instructions.rs
@@ -11,7 +11,7 @@ use hyperplane::{
         DepositAllTokenTypes, DepositSingleTokenTypeExactAmountIn, Swap, WithdrawAllTokenTypes,
         WithdrawSingleTokenTypeExactAmountOut,
     },
-    CurveParameters,
+    model::CurveParameters,
 };
 use hyperplane_fuzz::{
     native_account_data::NativeAccountData,
@@ -467,6 +467,10 @@ fn get_curve_parameters(curve_type: CurveType) -> CurveParameters {
         CurveType::Offset => CurveParameters::Offset {
             token_b_offset: 100_000_000_000,
         },
-        CurveType::Stable => CurveParameters::Stable { amp: 100 },
+        CurveType::Stable => CurveParameters::Stable {
+            amp: 100,
+            token_a_decimals: 6,
+            token_b_decimals: 6,
+        },
     }
 }

--- a/programs/hyperplane/fuzz/src/native_token.rs
+++ b/programs/hyperplane/fuzz/src/native_token.rs
@@ -6,11 +6,12 @@ use spl_token_2022::{
 
 use crate::native_account_data::NativeAccountData;
 
-pub fn create_mint(owner: &Pubkey) -> NativeAccountData {
+pub fn create_mint(owner: &Pubkey, decimals: u8) -> NativeAccountData {
     let mut account_data = NativeAccountData::new(Mint::LEN, spl_token::id());
     let mint = Mint {
         is_initialized: true,
         mint_authority: COption::Some(*owner),
+        decimals,
         ..Default::default()
     };
     Mint::pack(mint, &mut account_data.data[..]).unwrap();

--- a/programs/hyperplane/src/curve/calculator.rs
+++ b/programs/hyperplane/src/curve/calculator.rs
@@ -98,12 +98,18 @@ pub trait CurveCalculator: Debug + DynAccountSerialize {
 
     /// Get the amount of trading tokens for the given amount of pool tokens,
     /// provided the total trading tokens and supply of pool tokens.
+    /// Returns the amounts of trading tokens that were redeemed
+    /// * `pool_tokens` - the amount of pool tokens to burn
+    /// * `pool_token_supply` - the total supply of pool tokens
+    /// * `pool_token_a_amount` - the amount of token A in the pool
+    /// * `pool_token_b_amount` - the amount of token B in the pool
+    /// * `round_direction` - the direction to round the output trading token amounts
     fn pool_tokens_to_trading_tokens(
         &self,
         pool_tokens: u128,
         pool_token_supply: u128,
-        swap_token_a_amount: u128,
-        swap_token_b_amount: u128,
+        pool_token_a_amount: u128,
+        pool_token_b_amount: u128,
         round_direction: RoundDirection,
     ) -> Result<TradingTokenResult>;
 
@@ -282,11 +288,7 @@ pub mod test {
             1,
             pool_tokens_total_separate * epsilon_in_basis_points / 10000,
         );
-        let difference = if pool_tokens_from_one_side >= pool_tokens_total_separate {
-            pool_tokens_from_one_side - pool_tokens_total_separate
-        } else {
-            pool_tokens_total_separate - pool_tokens_from_one_side
-        };
+        let difference = pool_tokens_from_one_side.abs_diff(pool_tokens_total_separate);
         assert!(
             difference <= epsilon,
             "difference expected to be less than {}, actually {}",
@@ -367,11 +369,7 @@ pub mod test {
 
         // slippage due to rounding or truncation errors
         let epsilon = std::cmp::max(1, pool_token_amount * epsilon_in_basis_points / 10000);
-        let difference = if pool_token_amount >= pool_token_amount_from_single_side_withdraw {
-            pool_token_amount - pool_token_amount_from_single_side_withdraw
-        } else {
-            pool_token_amount_from_single_side_withdraw - pool_token_amount
-        };
+        let difference = pool_token_amount.abs_diff(pool_token_amount_from_single_side_withdraw);
         assert!(
             difference <= epsilon,
             "difference expected to be less than {}, actually {}",

--- a/programs/hyperplane/src/instructions/test/runner/token.rs
+++ b/programs/hyperplane/src/instructions/test/runner/token.rs
@@ -110,6 +110,7 @@ pub fn create_mint(
     freeze_authority: Option<&Pubkey>,
     close_authority: Option<&Pubkey>,
     fees: &TransferFee,
+    decimals: u8,
 ) -> (Pubkey, SolanaAccount) {
     let mint_key = Pubkey::new_unique();
 
@@ -121,7 +122,7 @@ pub fn create_mint(
             authority_key,
             freeze_authority,
             close_authority,
-            6,
+            decimals,
             fees,
         ),
     )

--- a/programs/hyperplane/src/instructions/test/test_deposit_all_token_types.rs
+++ b/programs/hyperplane/src/instructions/test/test_deposit_all_token_types.rs
@@ -21,8 +21,9 @@ use crate::{
         token,
     },
     ix,
+    model::CurveParameters,
     utils::seeds,
-    CurveParameters, InitialSupply,
+    InitialSupply,
 };
 
 #[test_case(spl_token::id(), spl_token::id(), spl_token::id(); "all-token")]
@@ -664,6 +665,7 @@ fn test_deposit(
             None,
             None,
             &TransferFee::default(),
+            6,
         );
         let old_pool_key = accounts.pool_token_mint_key;
         let old_pool_account = accounts.pool_token_mint_account;

--- a/programs/hyperplane/src/instructions/test/test_deposit_single_token_type.rs
+++ b/programs/hyperplane/src/instructions/test/test_deposit_single_token_type.rs
@@ -21,8 +21,9 @@ use crate::{
         token,
     },
     ix,
+    model::CurveParameters,
     utils::seeds,
-    CurveParameters, InitialSupply,
+    InitialSupply,
 };
 
 #[test_case(spl_token::id(), spl_token::id(), spl_token::id(); "all-token")]
@@ -488,6 +489,7 @@ fn test_deposit_one_exact_in(
             None,
             None,
             &TransferFee::default(),
+            6,
         );
         let old_pool_key = accounts.pool_token_mint_key;
         let old_pool_account = accounts.pool_token_mint_account;

--- a/programs/hyperplane/src/instructions/test/test_swap.rs
+++ b/programs/hyperplane/src/instructions/test/test_swap.rs
@@ -26,8 +26,9 @@ use crate::{
         token,
     },
     ix,
+    model::CurveParameters,
     utils::seeds,
-    CurveParameters, InitialSupply,
+    InitialSupply,
 };
 
 #[test_case(spl_token::id(), spl_token::id(), spl_token::id(); "all-token")]
@@ -95,6 +96,23 @@ fn test_valid_swap_curve_all_fees(
         &token_a_program_id,
         &token_b_program_id,
     );
+    let amp = 100;
+    let token_a_decimals = 6;
+    let token_b_decimals = 6;
+    assert::check_valid_swap_curve(
+        fees,
+        SwapTransferFees::default(),
+        CurveParameters::Stable {
+            amp,
+            token_a_decimals,
+            token_b_decimals,
+        },
+        token_a_amount,
+        token_b_amount,
+        &pool_token_program_id,
+        &token_a_program_id,
+        &token_b_program_id,
+    );
 }
 
 #[test_case(spl_token::id(), spl_token::id(), spl_token::id(); "all-token")]
@@ -155,6 +173,23 @@ fn test_valid_swap_curve_trade_fee_only(
         fees,
         SwapTransferFees::default(),
         CurveParameters::Offset { token_b_offset },
+        token_a_amount,
+        token_b_amount,
+        &pool_token_program_id,
+        &token_a_program_id,
+        &token_b_program_id,
+    );
+    let amp = 100;
+    let token_a_decimals = 6;
+    let token_b_decimals = 6;
+    assert::check_valid_swap_curve(
+        fees,
+        SwapTransferFees::default(),
+        CurveParameters::Stable {
+            amp,
+            token_a_decimals,
+            token_b_decimals,
+        },
         token_a_amount,
         token_b_amount,
         &pool_token_program_id,
@@ -246,7 +281,7 @@ fn test_valid_swap_with_fee_constraints(
             &accounts.token_b_program_id,
             accounts.fees,
             accounts.initial_supply.clone(),
-            accounts.curve_params.clone(),
+            accounts.curve_params.clone().into(),
         )
         .unwrap(),
         vec![
@@ -941,6 +976,7 @@ fn test_invalid_swap(
             None,
             None,
             &TransferFee::default(),
+            6,
         );
         let old_pool_key = accounts.pool_token_mint_key;
         let old_pool_account = accounts.pool_token_mint_account;

--- a/programs/hyperplane/src/instructions/test/test_withdraw_all_token_types.rs
+++ b/programs/hyperplane/src/instructions/test/test_withdraw_all_token_types.rs
@@ -21,8 +21,9 @@ use crate::{
         token,
     },
     ix,
+    model::CurveParameters,
     utils::seeds,
-    CurveParameters, InitialSupply,
+    InitialSupply,
 };
 
 #[test_case(spl_token::id(), spl_token::id(), spl_token::id(); "all-token")]
@@ -59,7 +60,7 @@ fn test_withdraw(
     let token_a_amount = 1000;
     let token_b_amount = 2000;
     let curve_params = CurveParameters::ConstantProduct;
-    let swap_curve = SwapCurve::new_from_params(curve_params.clone());
+    let swap_curve = SwapCurve::new_from_params(curve_params.clone()).unwrap();
 
     let withdrawer_key = Pubkey::new_unique();
     let initial_a = token_a_amount / 10;
@@ -603,6 +604,7 @@ fn test_withdraw(
             None,
             None,
             &TransferFee::default(),
+            6,
         );
         let old_pool_key = accounts.pool_token_mint_key;
         let old_pool_account = accounts.pool_token_mint_account;
@@ -950,7 +952,7 @@ fn test_withdraw_all_offset_curve(
 
     let token_b_offset = 2_000_000;
     let curve_params = CurveParameters::Offset { token_b_offset };
-    let swap_curve = SwapCurve::new_from_params(curve_params.clone());
+    let swap_curve = SwapCurve::new_from_params(curve_params.clone()).unwrap();
     let total_pool = swap_curve.calculator.new_pool_supply();
     let user_key = Pubkey::new_unique();
 
@@ -1050,7 +1052,7 @@ fn test_withdraw_all_constant_price_curve(
     };
 
     let curve_params = CurveParameters::ConstantPrice { token_b_price };
-    let swap_curve = SwapCurve::new_from_params(curve_params.clone());
+    let swap_curve = SwapCurve::new_from_params(curve_params.clone()).unwrap();
     let total_pool = swap_curve.calculator.new_pool_supply();
     let user_key = Pubkey::new_unique();
     let withdrawer_key = Pubkey::new_unique();

--- a/programs/hyperplane/src/instructions/test/test_withdraw_single_token_type.rs
+++ b/programs/hyperplane/src/instructions/test/test_withdraw_single_token_type.rs
@@ -21,8 +21,9 @@ use crate::{
         token,
     },
     ix,
+    model::CurveParameters,
     utils::seeds,
-    CurveParameters, InitialSupply,
+    InitialSupply,
 };
 
 #[test_case(spl_token::id(), spl_token::id(), spl_token::id(); "all-token")]
@@ -59,7 +60,7 @@ fn test_withdraw_one_exact_out(
     let token_a_amount = 100_000;
     let token_b_amount = 200_000;
     let curve_params = CurveParameters::ConstantProduct;
-    let swap_curve = SwapCurve::new_from_params(curve_params.clone());
+    let swap_curve = SwapCurve::new_from_params(curve_params.clone()).unwrap();
 
     let withdrawer_key = Pubkey::new_unique();
     let initial_a = token_a_amount / 10;
@@ -572,6 +573,7 @@ fn test_withdraw_one_exact_out(
             None,
             None,
             &TransferFee::default(),
+            6,
         );
         let old_pool_key = accounts.pool_token_mint_key;
         let old_pool_account = accounts.pool_token_mint_account;

--- a/programs/hyperplane/src/ix.rs
+++ b/programs/hyperplane/src/ix.rs
@@ -12,7 +12,7 @@ use anchor_lang::{
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
 
-use crate::{curve::fees::Fees, instructions::CurveParameters, InitialSupply};
+use crate::{curve::fees::Fees, instructions::CurveUserParameters, InitialSupply};
 
 /// Initialize instruction data
 #[derive(Debug, PartialEq)]
@@ -21,7 +21,7 @@ pub struct Initialize {
     pub fees: Fees,
     /// swap curve info for pool, including CurveType and anything
     /// else that may be required
-    pub curve: CurveParameters,
+    pub curve: CurveUserParameters,
 }
 
 /// Swap instruction data
@@ -103,7 +103,7 @@ pub fn initialize_pool(
     token_b_program_id: &Pubkey,
     fees: Fees,
     initial_supply: InitialSupply,
-    curve_parameters: CurveParameters,
+    curve_parameters: CurveUserParameters,
 ) -> Result<Instruction, ProgramError> {
     let data = super::instruction::InitializePool {
         initial_supply_a: initial_supply.initial_supply_a,

--- a/programs/hyperplane/src/lib.rs
+++ b/programs/hyperplane/src/lib.rs
@@ -28,7 +28,7 @@ pub mod hyperplane {
 
     pub fn initialize_pool(
         ctx: Context<InitializePool>,
-        curve_parameters: CurveParameters,
+        curve_parameters: CurveUserParameters,
         fees: Fees,
         initial_supply_a: u64,
         initial_supply_b: u64,


### PR DESCRIPTION
## Overview

- Add `token_a_factor` and `token_b_factor` fields to the `StableCurve` account
- Before any swap operation (or asymmetric deposit/withdrawal) - scale each input by the factor
- Such that:
```md
1 USDH = 1.000_000     = 1_000_000     => multiply by 10**3 = 1_000_000_000
1 UXD  = 1.000_000_000 = 1_000_000_000 => multiply by 10**0 = 1_000_000_000
```
- When scaling back down, each number should be rounded to favour the swap pool - round up amounts sent to the pool and round down amounts sent out of the pool
- Most changes are in `src/curve/stable.rs`